### PR TITLE
Upgrade Electron and Electron Mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
   "devDependencies": {
     "angular-mocks": "^1.4.7",
     "browserify": "^12.0.1",
-    "electron-mocha": "^0.6.1",
+    "electron-mocha": "^0.7.0",
     "electron-packager": "^5.1.1",
-    "electron-prebuilt": "^0.31.2",
+    "electron-prebuilt": "^0.36.0",
     "gulp": "^3.9.0",
     "gulp-jshint": "^1.11.2",
     "gulp-sass": "^2.0.4",


### PR DESCRIPTION
- electron-prebuilt@0.36.0
- electron-mocha@0.7.0

This versions fix the following issues on Travis CI and GNU/Linux
systems in general:

```
npm ERR! Linux 3.13.0-40-generic
npm ERR! argv "/home/travis/.nvm/versions/node/v4.0.0/bin/node"
"/home/travis/.nvm/versions/node/v4.0.0/bin/npm" "run-script" "test:main"
npm ERR! node v4.0.0
npm ERR! npm  v2.14.2
npm ERR! code ELIFECYCLE
npm ERR! herostratus@0.0.1 test:main: `electron-mocha --recursive
tests/src`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the herostratus@0.0.1 test:main script
'electron-mocha --recursive tests/src'.
npm ERR! This is most likely a problem with the herostratus package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     electron-mocha --recursive tests/src
npm ERR! You can get their info via:
npm ERR!     npm owner ls herostratus
npm ERR! There is likely additional logging output above.
npm ERR! Please include the following file with any support request:
npm ERR!     /home/travis/build/resin-io/herostratus/npm-debug.log
npm ERR! Test failed.  See above for more details.
```
***
```
A JavaScript error occurred in the main process
Uncaught Exception:
Error: Failed to set path
    at Error (native)
      at Object.<anonymous>
(/home/jviotti/Projects/herostratus/node_modules/electron-prebuilt/dist/resources/atom.asar/browser/lib/init.js:120:7)
      at Object.<anonymous>
(/home/jviotti/Projects/herostratus/node_modules/electron-prebuilt/dist/resources/atom.asar/browser/lib/init.js:132:4)
      at Module._compile (module.js:434:26)
      at Object.Module._extensions..js (module.js:452:10)
      at Module.load (module.js:355:32)
      at Function.Module._load (module.js:310:12)
      at Function.Module.runMain (module.js:475:10)
      at startup (node.js:130:18)
      at node.js:982:3
```