### PR TITLE
Do not append a backslash after drive letter in Windows

### DIFF
--- a/lib/index.html
+++ b/lib/index.html
@@ -58,7 +58,7 @@
 
                             <!-- Show drive letter instead of phsycal drive name on Windows -->
                             <span ng-if="app.platform == 'win32'"
-                              ng-bind="'Drive ' + drive.mountpoint + '\\ - ' + drive.size"></span>
+                              ng-bind="'Drive ' + drive.mountpoint + ' - ' + drive.size"></span>
                             <span ng-if="app.platform != 'win32'"
                               ng-bind="drive.device + ' - ' + drive.size"></span>
 
@@ -74,7 +74,7 @@
 
                 </div>
                 <div ng-show="app.selection.hasDrive()">
-                  <span ng-if="app.platform == 'win32'" ng-bind="app.selection.getDrive().mountpoint + '\\'"></span>
+                  <span ng-if="app.platform == 'win32'" ng-bind="app.selection.getDrive().mountpoint"></span>
                   <span ng-if="app.platform != 'win32'" ng-bind="app.selection.getDrive().device"></span>
                 </div>
               </div>


### PR DESCRIPTION
After checking Windows file manager and some other programs that display
drive letters, we can see that a backslash at the end is not mandatory.