### PR TITLE
Simplify drive letter / device conditional

### DIFF
--- a/build/browser/app.js
+++ b/build/browser/app.js
@@ -72,8 +72,6 @@ app.controller('AppController', function($q, DriveScannerService, SelectionState
     console.debug('Drive selected: ' + drive.device);
   };
 
-  this.platform = window.process.platform;
-
   this.burn = function(image, drive) {
 
     // Stop scanning drives when burning

--- a/lib/browser/app.js
+++ b/lib/browser/app.js
@@ -71,8 +71,6 @@ app.controller('AppController', function($q, DriveScannerService, SelectionState
     console.debug('Drive selected: ' + drive.device);
   };
 
-  this.platform = window.process.platform;
-
   this.burn = function(image, drive) {
 
     // Stop scanning drives when burning

--- a/lib/index.html
+++ b/lib/index.html
@@ -54,15 +54,7 @@
 
                       <ul class="dropdown-menu">
                         <li ng-repeat="drive in app.scanner.drives">
-                          <a href="#" ng-click="app.selectDrive(drive)">
-
-                            <!-- Show drive letter instead of phsycal drive name on Windows -->
-                            <span ng-if="app.platform == 'win32'"
-                              ng-bind="'Drive ' + drive.mountpoint + ' - ' + drive.size"></span>
-                            <span ng-if="app.platform != 'win32'"
-                              ng-bind="drive.device + ' - ' + drive.size"></span>
-
-                          </a>
+                          <a href="#" ng-click="app.selectDrive(drive)" ng-bind="drive.name + ' - ' + drive.size"></a>
                         </li>
                       </ul>
                     </div>
@@ -73,10 +65,7 @@
                   </div>
 
                 </div>
-                <div ng-show="app.selection.hasDrive()">
-                  <span ng-if="app.platform == 'win32'" ng-bind="app.selection.getDrive().mountpoint"></span>
-                  <span ng-if="app.platform != 'win32'" ng-bind="app.selection.getDrive().device"></span>
-                </div>
+                <div ng-show="app.selection.hasDrive()" ng-bind="app.selection.getDrive().name"></div>
               </div>
             </div>
           </div>

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "angular-ui-bootstrap": "^0.14.2",
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
-    "drivelist": "^2.0.4",
+    "drivelist": "^2.0.7",
     "electron-window": "^0.6.0",
     "flexboxgrid": "^6.3.0",
     "is-elevated": "^1.0.0",


### PR DESCRIPTION
The `drivelist` module includes a new property called `name` in `2.0.7`
that resolves to the drive letter (mount point) on Windows, and to the
drive otherwise.