### PR TITLE
Set an explicit maxlen

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -41,6 +41,7 @@
     "undef"         : true,     // Require all non-global variables be declared before they are used.
     "strict"        : true,     // Require `use strict` pragma in every file.
     "trailing"      : true,     // Prohibit trailing whitespaces.
+    "maxlen"        : 130,      // Limit line length.
 
     // == Relaxing Options ================================================
     //


### PR DESCRIPTION
Hound CI uses it's default otherwise, which is too short.