### PR TITLE
Only target v4 in CI servers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ notifications:
 language: node_js
 node_js:
   - "4.0"
-  - "0.12"
-  - "0.10"
-  - "iojs"
 before_script:
   - npm install -g electron-prebuilt
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,6 @@ cache:
 # what combinations to test
 environment:
   matrix:
-    - nodejs_version: 0.10
-    - nodejs_version: 0.12
     - nodejs_version: 4
 
 install:


### PR DESCRIPTION
We're only targetting Electron, which uses only modern versions of
NodeJS.