### PR TITLE
Require electron-window as ElectronWindow

### DIFF
--- a/lib/etcher.js
+++ b/lib/etcher.js
@@ -18,7 +18,7 @@ var globalShortcut = require('global-shortcut');
 var path = require('path');
 var app = require('app');
 var Menu = require('menu');
-var Window = require('electron-window');
+var ElectronWindow = require('electron-window');
 var elevate = require('./elevate');
 
 app.on('window-all-closed', app.quit);
@@ -35,7 +35,7 @@ app.on('ready', function() {
       throw error;
     }
 
-    var mainWindow = Window.createWindow({
+    var mainWindow = ElectronWindow.createWindow({
       width: 800,
       height: 380,
       resizable: false,


### PR DESCRIPTION
JSHint complains about `Window` as a redefinition warning.