### PR TITLE
Allow to re-select the first two step selections

### DIFF
--- a/build/browser/app.js
+++ b/build/browser/app.js
@@ -670,6 +670,30 @@ selectionState.service('SelectionStateService', function() {
   };
 
   /**
+   * @summary Remove drive
+   * @function
+   * @public
+   *
+   * @example
+   * SelectionStateService.removeDrive();
+   */
+  this.removeDrive = function() {
+    self.setDrive(undefined);
+  };
+
+  /**
+   * @summary Remove image
+   * @function
+   * @public
+   *
+   * @example
+   * SelectionStateService.removeImage();
+   */
+  this.removeImage = function() {
+    self.setImage(undefined);
+  };
+
+  /**
    * @summary Clear all selections
    * @function
    * @public

--- a/build/browser/app.js
+++ b/build/browser/app.js
@@ -93,6 +93,29 @@ app.controller('AppController', function($q, DriveScannerService, SelectionState
     console.debug('Drive selected: ' + drive.device);
   };
 
+  this.reselectImage = function() {
+    if (self.writer.isBurning()) {
+      return;
+    }
+
+    // Reselecting an image automatically
+    // de-selects the current drive, if any.
+    // This is made so the user effectively
+    // "returns" to the first step.
+    self.selection.clear();
+
+    console.debug('Reselecting image');
+  };
+
+  this.reselectDrive = function() {
+    if (self.writer.isBurning()) {
+      return;
+    }
+
+    self.selection.removeDrive();
+    console.debug('Reselecting drive');
+  };
+
   this.burn = function(image, drive) {
 
     // Stop scanning drives when burning

--- a/lib/browser/app.js
+++ b/lib/browser/app.js
@@ -92,6 +92,29 @@ app.controller('AppController', function($q, DriveScannerService, SelectionState
     console.debug('Drive selected: ' + drive.device);
   };
 
+  this.reselectImage = function() {
+    if (self.writer.isBurning()) {
+      return;
+    }
+
+    // Reselecting an image automatically
+    // de-selects the current drive, if any.
+    // This is made so the user effectively
+    // "returns" to the first step.
+    self.selection.clear();
+
+    console.debug('Reselecting image');
+  };
+
+  this.reselectDrive = function() {
+    if (self.writer.isBurning()) {
+      return;
+    }
+
+    self.selection.removeDrive();
+    console.debug('Reselecting drive');
+  };
+
   this.burn = function(image, drive) {
 
     // Stop scanning drives when burning

--- a/lib/browser/modules/selection-state.js
+++ b/lib/browser/modules/selection-state.js
@@ -124,6 +124,30 @@ selectionState.service('SelectionStateService', function() {
   };
 
   /**
+   * @summary Remove drive
+   * @function
+   * @public
+   *
+   * @example
+   * SelectionStateService.removeDrive();
+   */
+  this.removeDrive = function() {
+    self.setDrive(undefined);
+  };
+
+  /**
+   * @summary Remove image
+   * @function
+   * @public
+   *
+   * @example
+   * SelectionStateService.removeImage();
+   */
+  this.removeImage = function() {
+    self.setImage(undefined);
+  };
+
+  /**
    * @summary Clear all selections
    * @function
    * @public

--- a/lib/index.html
+++ b/lib/index.html
@@ -30,7 +30,7 @@
                   <hero-button ng-click="app.selectImage()">Select image</hero-button>
                 </div>
                 <div ng-show="app.selection.hasImage()">
-                  <span ng-bind="app.selection.getImage() | basename"></span>
+                  <span ng-bind="app.selection.getImage() | basename" ng-click="app.reselectImage()"></span>
                 </div>
 
                 <p class="step-footer tiny">*supported files: .img, .iso</p>
@@ -67,7 +67,7 @@
                   </div>
 
                 </div>
-                <div ng-show="app.selection.hasDrive()" ng-bind="app.selection.getDrive().name"></div>
+                <div ng-show="app.selection.hasDrive()" ng-bind="app.selection.getDrive().name" ng-click="app.reselectDrive()"></div>
               </div>
             </div>
           </div>

--- a/tests/browser/modules/selection-state.spec.js
+++ b/tests/browser/modules/selection-state.spec.js
@@ -78,6 +78,17 @@ describe('Browser: SelectionState', function() {
 
       });
 
+      describe('.removeDrive()', function() {
+
+        it('should clear the drive', function() {
+          SelectionStateService.removeDrive();
+          var drive = SelectionStateService.getDrive();
+          m.chai.expect(drive).to.be.undefined;
+        });
+
+      });
+
+
     });
 
     describe('given no drive', function() {
@@ -124,6 +135,16 @@ describe('Browser: SelectionState', function() {
           SelectionStateService.setImage('bar.img');
           var image = SelectionStateService.getImage();
           m.chai.expect(image).to.equal('bar.img');
+        });
+
+      });
+
+      describe('.removeImage()', function() {
+
+        it('should clear the image', function() {
+          SelectionStateService.removeImage();
+          var image = SelectionStateService.getImage();
+          m.chai.expect(image).to.be.undefined;
         });
 
       });


### PR DESCRIPTION
You can click on the selected image/drive label to select them again.

The re-selection is disabled if there is a burning in process.

Fixes: https://github.com/resin-io/resin-etcher/issues/90